### PR TITLE
一个nil对象加到了dictionary 会蹦

### DIFF
--- a/ios/RCTWeChat.m
+++ b/ios/RCTWeChat.m
@@ -66,6 +66,7 @@ RCT_EXPORT_METHOD(registerAppWithDescription:(NSString *)appid
                   :(NSString *)appdesc
                   :(RCTResponseSenderBlock)callback)
 {
+    self.appId = appid;
     callback(@[[WXApi registerApp:appid withDescription:appdesc] ? [NSNull null] : INVOKE_FAILED]);
 }
 


### PR DESCRIPTION
[body addEntriesFromDictionary:@{@"appid":self.appId, @"code" :r.code}];
在使用registerAppWithDescription初始后, 在微信登录的回调 中self.appId 为nil