### PR TITLE
JS: compatible with the environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,7 +267,11 @@ export class WechatError extends Error {
 
     // avoid babel's limition about extending Error class
     // https://github.com/babel/babel/issues/3083
-    Object.setPrototypeOf(this, WechatError.prototype);
+    if (typeof Object.setPrototypeOf === 'function') {
+      Object.setPrototypeOf(this, WechatError.prototype);
+    } else {
+      this.__proto__ = WechatError.prototype;
+    }
   }
 }
 


### PR DESCRIPTION
compatible with the environment which doesn't have `Object.setPrototypeOf`

Fixes: #228