### PR TITLE
允许修改APPID和timeStamp类型要求不一样

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,10 +18,6 @@ function wrapRegisterApp(nativeFunc) {
     return undefined;
   }
   return (...args) => {
-    if (isAppRegistered) {
-      // FIXME(Yorkie): we ignore this error if AppRegistered is true.
-      return Promise.resolve(true);
-    }
     isAppRegistered = true;
     return new Promise((resolve, reject) => {
       nativeFunc.apply(null, [

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { DeviceEventEmitter, NativeModules } from 'react-native';
+import { DeviceEventEmitter, NativeModules, Platform } from 'react-native';
 import { EventEmitter } from 'events';
 
 let isAppRegistered = false;
@@ -253,6 +253,7 @@ export function pay(data) {
   // FIXME(Yorkie): see https://github.com/yorkie/react-native-wechat/issues/203
   // Here the server-side returns params in lowercase, but here SDK requires timeStamp
   // for compatibility, we make this correction for users.
+  if(Platform.OS !== 'ios') data.timeStamp = String(timeStamp)
   function correct(actual, fixed) {
     if (!data[fixed] && data[actual]) {
       data[fixed] = data[actual];

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 import { DeviceEventEmitter, NativeModules, Platform } from 'react-native';
 import { EventEmitter } from 'events';
 
-let isAppRegistered = false;
+let wxAppId = null;
 const { WeChat } = NativeModules;
 
 // Event emitter to dispatch request and response from WeChat.
@@ -18,7 +18,8 @@ function wrapRegisterApp(nativeFunc) {
     return undefined;
   }
   return (...args) => {
-    isAppRegistered = true;
+    if(wxAppId === args[0]) return true;
+    wxAppId = true;
     return new Promise((resolve, reject) => {
       nativeFunc.apply(null, [
         ...args,
@@ -41,7 +42,7 @@ function wrapApi(nativeFunc) {
     return undefined;
   }
   return (...args) => {
-    if (!isAppRegistered) {
+    if (!wxAppId) {
       return Promise.reject(new Error('registerApp required.'));
     }
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
1. 登录分享和支付使用是2个APPID (后端是这么做的，无奈)，所以添加允许多次注册，即可以修改APPID。
2. 支付 timeStamp 字段 android要求是String , ios是number，通过平台转换类型。