### PR TITLE
Explicitly set requiresMainQueueSetup

### DIFF
--- a/ios/RCTWeChat.m
+++ b/ios/RCTWeChat.m
@@ -55,6 +55,10 @@ RCT_EXPORT_MODULE()
     return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
 RCT_EXPORT_METHOD(registerApp:(NSString *)appid
                   :(RCTResponseSenderBlock)callback)
 {


### PR DESCRIPTION
Fixes warning on startup:


> Module RCTWeChat requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.