### PR TITLE
修复 “XCTest 引入到打包结果里” 的问题

### DIFF
--- a/ios/RCTWeChat.podspec
+++ b/ios/RCTWeChat.podspec
@@ -26,13 +26,17 @@ Pod::Spec.new do |s|
   s.author             = { "weflex" => "336021910@qq.com" }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/weflex/react-native-wechat.git", :tag => "master" }
-  s.source_files  = "**/*.{h,m}"
+  s.source_files  = "*.{h,m}"
   s.requires_arc = true
 
   # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
   s.dependency "React"
   s.vendored_libraries = "libWeChatSDK.a"
-  s.ios.frameworks = 'SystemConfiguration','CoreTelephony','XCTest'
+  s.ios.frameworks = 'SystemConfiguration','CoreTelephony'
   s.ios.library = 'sqlite3','c++','z'
 
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.ios.frameworks = 'XCTest'
+    test_spec.source_files  = "RCTWeChatTests/*.{h,m}"
+  end
 end


### PR DESCRIPTION
因为打包的文件里有XCTest的依赖，在设备里运行的时候没能加载XCTest.framework而闪退
https://github.com/yorkie/react-native-wechat/issues/344#issuecomment-517570764
所以把XCTest移到测试spec里了