### PR TITLE
fix unreported exception during build

### DIFF
--- a/android/src/main/java/com/theweflex/react/WeChatModule.java
+++ b/android/src/main/java/com/theweflex/react/WeChatModule.java
@@ -252,7 +252,7 @@ public class WeChatModule extends ReactContextBaseJavaModule implements IWXAPIEv
                         imageCallback.invoke(bitmap);
                     }
                 } else {
-                    throw new Exception("Empty bitmap");
+                    imageCallback.invoke(null);
                 }
             }
 


### PR DESCRIPTION
## Error
This pr fixes a build error which happens on current master
这修复了当前在构建时发生的构建错误。

```bash
java/com/theweflex/react/WeChatModule.java:255: error: unreported exception Exception; must be caught or declared to be thrown
                    throw new Exception("Empty bitmap");
                    ^
1 error

FAILURE: Build failed with an exception.
```

## Fix
Variable `bitmap` is explicitly annotated with `@Nullable` in the invocation callback, so calling the callback with `null` in the failure case makes total sense to me.
```java
this._getImage(imageUri, null, new ImageCallback() {
    @Override
    public void invoke(@Nullable Bitmap bitmap) {
        callback.invoke(bitmap == null ? null : new WXImageObject(bitmap));
    }
});
```