### PR TITLE
podspec修改

### DIFF
--- a/RCTWeChat.podspec
+++ b/RCTWeChat.podspec
@@ -7,7 +7,7 @@
 #
 
 Pod::Spec.new do |s|
-  s.name         = "react-native-wechat"
+  s.name         = "RCTWeChat"
   s.version      = "1.9.10"
   s.summary      = "React-Native(iOS/Android) functionalities include WeChat Login, Share, Favorite and Payment {QQ: 336021910}"
   s.description  = <<-DESC

--- a/RCTWeChat.podspec
+++ b/RCTWeChat.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RCTWeChat"
-  s.version      = "1.9.10"
+  s.version      = "1.9.11"
   s.summary      = "React-Native(iOS/Android) functionalities include WeChat Login, Share, Favorite and Payment {QQ: 336021910}"
   s.description  = <<-DESC
   React-Native(iOS/Android) functionalities include WeChat Login, Share, Favorite and Payment {QQ: 336021910}


### PR DESCRIPTION
最新版本`1.9.11 `，在 `RN 0,60.5`上，执行`pod install`，报错：
```
[!] No podspec found for `RCTWeChat` in `../node_modules/react-native-wechat`
```
我自己`fork`一份，做如下修改后，`pod install` 成功，我不是`iOS` 开发者，不知道改的对不对。提一个`PR` 给大佬看看。