### PR TITLE
fix interface ShareMetadata

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,7 @@ declare module "react-native-wechat" {
       | "audio"
       | "file";
     thumbImage?: string;
+    title?: string,
     description?: string;
     webpageUrl?: string;
     imageUrl?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ declare module "react-native-wechat" {
       | "audio"
       | "file";
     thumbImage?: string;
-    title?: string,
+    title?: string;
     description?: string;
     webpageUrl?: string;
     imageUrl?: string;


### PR DESCRIPTION
修复ShareMetaddata这个interface

不添加title时，用户调用wechat.shareToTimeline或者wechat.shareToSession进行分享时，会没有标题，导致对话列表出现[链接]null的情况