### PR TITLE
android: fix the error (#549)

### DIFF
--- a/android/src/main/java/com/theweflex/react/WeChatModule.java
+++ b/android/src/main/java/com/theweflex/react/WeChatModule.java
@@ -97,7 +97,8 @@ public class WeChatModule extends ReactContextBaseJavaModule implements IWXAPIEv
 
     public static void handleIntent(Intent intent) {
         for (WeChatModule mod : modules) {
-            mod.api.handleIntent(intent, mod);
+            if (mod.api != null)
+                mod.api.handleIntent(intent, mod);
         }
     }
 


### PR DESCRIPTION
Please read and follow the issue templates:

1. Bug Report or Documentation Issue or Questions and Help?
YES
2. Which `react-native-wechat` version are you using?
1.9.12
3. What platform does your issue occur on? (Android/iOS/Both)
android
4. Please provide a clear and concise description of what the bug is as precisely as possible，you can: 

Logs from Sentry：
```
java.lang.NullPointerException: Attempt to invoke interface method 'boolean com.tencent.mm.sdk.openapi.IWXAPI.handleIntent(android.content.Intent, com.tencent.mm.sdk.openapi.IWXAPIEventHandler)' on a null object reference
    at com.theweflex.react.WeChatModule.handleIntent(WeChatModule.java:2)
    at com.xxxx.xxxx.wxapi.WXEntryActivity.onCreate(WXEntryActivity.java:2)
    at android.app.Activity.performCreate(Activity.java:6355)
    at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1108)
    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2440)
    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2547)
    at android.app.ActivityThread.access$1100(ActivityThread.java:151)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1398)
    at android.os.Handler.dispatchMessage(Handler.java:102)
    at android.os.Looper.loop(Looper.java:157)
    at android.app.ActivityThread.main(ActivityThread.java:5603)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:774)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:652)
```

### Your Environment

| software         | version
| ---------------- | -------
| react-native-wechat |  ^ 1.9.12
| react-native     | ^ 2.0.1
| node             | ^ 12.14.1.
| npm or yarn      | ^ 6.13.7
