### PR TITLE
Develop

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,7 @@
+{
+  "ignore_dirs": [
+    ".git",
+    "node_modules",
+    "playground"
+  ]
+}

--- a/android/src/main/java/com/theweflex/react/WeChatModule.java
+++ b/android/src/main/java/com/theweflex/react/WeChatModule.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.common.executors.UiThreadImmediateExecutorService;
 import com.facebook.common.internal.Files;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
-{
+re{
   "name": "react-native-wechat",
-  "version": "1.9.12",
+  "version": "2.0.0",
   "description": "react-native library for wechat app",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
支持androidX其实很简单替换对应的库就可以了。最好用2.0.0+来表示支持rn0.60+的版本。1.9.12+用来支持0.60以下的版本。